### PR TITLE
Add useLeafletLatLngBounds hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 node_modules
 *.log
 flow-typed/npm
+.yalc
+yalc.lock

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Installation: `npm i use-leaflet`
 -   [useLeafletBounds](#useleafletbounds)
 -   [useLeafletIsMoving](#useleafletismoving)
 -   [useLeafletIsZooming](#useleafletiszooming)
+-   [useLeafletLatLngBounds](#useleafletlatlngbounds)
 -   [Map](#map)
 
 ### useLeafletZoom
@@ -119,6 +120,20 @@ const MyComponent = () => {
 ```
 
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** true if a user is zooming the map.
+
+### useLeafletLatLngBounds
+
+React hook for getting current latlng bounds of visible area of react-leaflet [Map](https://react-leaflet.js.org/docs/en/components.html#map).
+This hook is different from useLeafletBounds because it returns the Leaflet LatLngBounds object
+
+```javascript
+const MyComponent = () => {
+  const latLngBounds = useLeafletBounds()
+  return ...
+}
+```
+
+Returns **(LatLngBounds | null)** LatLngBounds for visible area.
 
 ### Map
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,9 @@
-import { Map } from "leaflet"
+import { Map, LatLngBounds } from "leaflet"
 
 export function useLeafletZoom(): number
 export function useLeafletMap(): Map | undefined
 export function useLeafletBounds(): [[number, number], [number, number]]
+export function useLeafletLatLngBounds(): LatLngBounds
 export function useLeafletCenter(): [number, number]
 export function useLeafletIsMoving(): boolean
 export function useLeafletIsZooming(): boolean

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 export { useLeafletZoom } from "./useLeafletZoom"
 export { useLeafletMap } from "./useLeafletMap"
 export { useLeafletBounds } from "./useLeafletBounds"
+export { useLeafletLatLngBounds } from "./useLeafletLatLngBounds"
 export { useLeafletCenter } from "./useLeafletCenter"
 export { useLeafletIsMoving } from "./useLeafletIsMoving"
 export { useLeafletIsZooming } from "./useLeafletIsZooming"

--- a/src/useLeafletLatLngBounds.js
+++ b/src/useLeafletLatLngBounds.js
@@ -1,6 +1,6 @@
 // @flow
-import { useLeafletData } from "./onLeafletEvent"
 import type { LatLngBounds } from "leaflet"
+import { useLeafletData } from "./onLeafletEvent"
 
 /**
  * React hook for getting current latlng bounds of visible area of react-leaflet [Map](https://react-leaflet.js.org/docs/en/components.html#map).

--- a/src/useLeafletLatLngBounds.js
+++ b/src/useLeafletLatLngBounds.js
@@ -1,0 +1,24 @@
+// @flow
+import { useLeafletData } from "./onLeafletEvent"
+import type { LatLngBounds } from "leaflet"
+
+/**
+ * React hook for getting current latlng bounds of visible area of react-leaflet [Map](https://react-leaflet.js.org/docs/en/components.html#map).
+ * This hook is different from useLeafletBounds because it returns the Leaflet LatLngBounds object
+ *
+ * ```javascript
+ * const MyComponent = () => {
+ *   const latLngBounds = useLeafletBounds()
+ *   return ...
+ * }
+ * ```
+ *
+ * @returns LatLngBounds for visible area.
+ */
+
+export const useLeafletLatLngBounds = (): LatLngBounds | null => useLeafletData(getMapBounds, "moveend")
+
+const getMapBounds = map => {
+	if (!map) return null
+	return map.getBounds()
+}


### PR DESCRIPTION
Leaflet exposes an object `LatLngBounds` which has usefull functions like e.g. `getNorthWest()` which returns me the lat/lng coordinates for this corner.

I exposed this bounds object via `useLeafletLatLngBounds()` being related to `useLeafletBounds()` but also clearly different.